### PR TITLE
add syntactic sugar to Logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(HFormatter)
 # 3rd party
 include_directories("3rd-header/")	# header-only library
 SUBDIRLIST(THIRD_LIBS "${CMAKE_CURRENT_LIST_DIR}/3rd-lib")
+set_property(GLOBAL PROPERTY G_THIRD_LIBS "${THIRD_LIBS}")
 foreach(THIRD_LIB ${THIRD_LIBS})
 	add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/3rd-lib/${THIRD_LIB}")
 endforeach()
@@ -25,7 +26,14 @@ include_directories("header/")
 # collect all sources
 aux_source_directory("source/" ALL_SRCS)
 
+add_library(libHFormatter SHARED ${ALL_SRCS})
+target_include_directories(libHFormatter PRIVATE ${THIRD_LIBS})
+target_link_libraries(libHFormatter ${THIRD_LIBS})
+
 # todo: add_executable/add_library
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${THIRD_LIBS})
-target_link_libraries(${PROJECT_NAME} ${THIRD_LIBS})
+# target_include_directories(${PROJECT_NAME} PRIVATE ${THIRD_LIBS})
+# target_link_libraries(${PROJECT_NAME} ${THIRD_LIBS})
+
+# build tests
+add_subdirectory("tests/")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,20 @@ macro(SUBDIRLIST result curdir)
 endmacro()
 project(HFormatter)
 
+if(NOT DEFINED BUILD_TYPE)
+  set(BUILD_TYPE "Release")
+endif()
+
+if("${BUILD_TYPE}" STREQUAL "Release")
+	add_compile_options(-Wall -s -O3)
+elseif("${BUILD_TYPE}" STREQUAL "Debug")
+	add_compile_options(-Wall -g -O0)
+else()
+	message(FATAL_ERROR "Unknown build type")
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Out")
+
 # 3rd party
 include_directories("3rd-header/")	# header-only library
 SUBDIRLIST(THIRD_LIBS "${CMAKE_CURRENT_LIST_DIR}/3rd-lib")
@@ -24,11 +38,12 @@ file(GLOB ALL_INCLUDES "header/*.hpp")
 include_directories("header/")
 
 # collect all sources
-aux_source_directory("source/" ALL_SRCS)
+#aux_source_directory("source/" ALL_SRCS)
 
-add_library(libHFormatter SHARED ${ALL_SRCS})
-target_include_directories(libHFormatter PRIVATE ${THIRD_LIBS})
-target_link_libraries(libHFormatter ${THIRD_LIBS})
+#add_library(libHFormatter SHARED ${ALL_SRCS})
+#target_include_directories(libHFormatter PRIVATE ${THIRD_LIBS})
+#target_link_libraries(libHFormatter ${THIRD_LIBS})
+add_subdirectory("source/")
 
 # todo: add_executable/add_library
 

--- a/header/logger.hpp
+++ b/header/logger.hpp
@@ -7,6 +7,6 @@ namespace HFormatter::NLogger{
             std::shared_ptr<spdlog::logger> logger_;
             Logger();
         public:
-            std::shared_ptr<spdlog::logger>& operator()();
+            std::shared_ptr<spdlog::logger>& operator->();
     };
 }

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(HFormatter_sources)
+
+add_library(Logger SHARED console_logger.cpp logger.cpp)
+target_include_directories(Logger PRIVATE spdlog)
+target_link_libraries(Logger spdlog)
+
+add_library(StringCounter SHARED string_counter.cpp)
+
+add_library(FileOperator SHARED file_operator.cpp)
+target_link_libraries(FileOperator StringCounter)
+
+add_library(PartIdentifier SHARED part_identifier.cpp)
+
+add_library(IdentifierGenerator SHARED identifier_generator.cpp)
+target_link_libraries(IdentifierGenerator PartIdentifier)
+
+add_library(PartInfo SHARED part_info.cpp)
+
+add_library(Indexer SHARED indexer.cpp)
+target_link_libraries(Indexer PartIdentifier PartInfo)
+
+add_library(PartIterator SHARED part_iterator.cpp)
+
+add_library(PathCompleter SHARED path_completer.cpp)
+
+add_library(PackageBuilder SHARED package_builder.cpp haru_package_builder.cpp)
+target_include_directories(PackageBuilder PRIVATE libharu)
+target_link_libraries(PackageBuilder libharu PartInfo)

--- a/source/console_logger.cpp
+++ b/source/console_logger.cpp
@@ -3,5 +3,5 @@
 using HFormatter::NLogger::ConsoleLogger;
 ConsoleLogger::ConsoleLogger(){
     logger_ = spdlog::stdout_color_st("console logger");
-    logger_->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%!] [%^%l%$] %v");
+    logger_->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%^%l%$] %v");
 }

--- a/source/logger.cpp
+++ b/source/logger.cpp
@@ -1,6 +1,5 @@
 #include<logger.hpp>
-#include<stdexcept>
 using std::shared_ptr;
 using HFormatter::NLogger::Logger;
 Logger::Logger():logger_(nullptr){};
-shared_ptr<spdlog::logger>& Logger::operator()(){return logger_;}
+shared_ptr<spdlog::logger>& Logger::operator->(){return logger_;}


### PR DESCRIPTION
Allow `Logger->info()` etc.. No more `Logger()->info()`.